### PR TITLE
fix: dont allow to edit system roles [SAW-944]

### DIFF
--- a/src/components/companies/roles/form.vue
+++ b/src/components/companies/roles/form.vue
@@ -25,6 +25,7 @@
                                 name="name"
                                 type="text"
                                 class="form-control"
+                                :disabled="isSystemRole"
                             >
                             <span class="text-danger">{{ errors.first("name") }}</span>
                         </div>
@@ -38,6 +39,7 @@
                                 type="text"
                                 name="description"
                                 class="form-control"
+                                :disabled="isSystemRole"
                             >
                             <span class="text-danger">{{ errors.first("description") }}</span>
                         </div>
@@ -60,6 +62,7 @@
                                         v-model="group.isGroupSelected"
                                         type="checkbox"
                                         class="form-check-input"
+                                        :disabled="isSystemRole"
                                         @click="checkGroup(group, groupName)"
                                     >
                                     <label class="form-check-label" :for="`group-${groupName}`" />
@@ -77,6 +80,7 @@
                                             :name="`checkbox-${groupName}-${accessName}`"
                                             type="checkbox"
                                             class="form-check-input"
+                                            :disabled="isSystemRole"
                                             @change="checkSelectedGroup(groupName, true)"
                                         >
                                         <label
@@ -97,7 +101,12 @@
                     <button class="btn btn-danger mr-2" @click="rolesList()">
                         Cancel
                     </button>
-                    <button :disabled="!hasChanged" class="btn btn-primary" @click="verifyFields()">
+                    <button
+                        v-if="!isSystemRole"
+                        :disabled="!hasChanged"
+                        class="btn btn-primary"
+                        @click="verifyFields()"
+                    >
                         Save
                     </button>
                 </div>
@@ -137,6 +146,9 @@ export default {
         },
         hasChanged() {
             return some(this.vvFields, field => field.changed) || this.groupHasChanged.length;
+        },
+        isSystemRole() {
+            return Number(this.roleData.apps_id) == 1;
         }
     },
     watch: {

--- a/src/components/companies/roles/list.vue
+++ b/src/components/companies/roles/list.vue
@@ -75,7 +75,7 @@ export default {
         },
 
         isGlobal(role) {
-            return Number(role.apps_id) == 0;
+            return Number(role.apps_id) == 1;
         },
 
         deleteRole(id) {


### PR DESCRIPTION
### Description
**Jira Ticket: [SAW-944]**

This PR hides the Edit and Delete button when the role is a System Role and Disable the fields and hide the save button if the user forces the route to enter to the Edit Role form.

### Why
We need to prevent the users from editing/delete System roles.

### How
- Add `v-if` to only display the Edit/Delete button if the Role is not a System Role
- Disable fields and checks of the access list if is a System Role in Edit Role


#### Checklist
- [x] The branch is updated with the main branch.
- [x] I have performed a self-review of my own code.
- [x] My code follows the style guidelines of this project.
- [ ] I have made corresponding changes to the documentation.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I add/change environment variables and I updated the dev/prod keys and notify my partners.

[SAW-944]: https://mctekk.atlassian.net/browse/SAW-944